### PR TITLE
Added empty constructor to Session

### DIFF
--- a/src/Session.php
+++ b/src/Session.php
@@ -29,6 +29,13 @@ class Session extends Nette\Http\Session
 
 
 
+	public function __construct()
+	{
+		// no dependencies
+	}
+
+
+
 	public function start()
 	{
 		// nope


### PR DESCRIPTION
In unit tests I don't always use DIC so I'd like to create the fake session easily without dependencies. Of course I can do it even now like this:

```php
$this->session = Mockery::mock(\Kdyby\FakeSession\Session::class);
$this->session->shouldDeferMissing();
```

Also I'm wondering about [these two methods](https://github.com/Kdyby/FakeSession/blob/master/src/Session.php#L113-L123). If they just call the parent method, it's useless to override them. In this case though I think they shouldn't call the parent method and should only call `return $this;`.