### PR TITLE
Implemented factory resolving which session should be used

### DIFF
--- a/src/SessionFactory.php
+++ b/src/SessionFactory.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * This file is part of the Kdyby (http://www.kdyby.org)
+ *
+ * Copyright (c) 2008 Filip Procházka (filip@prochazka.su)
+ *
+ * For the full copyright and license information, please view the file license.txt that was distributed with this source code.
+ */
+
+namespace Kdyby\FakeSession;
+
+use Nette;
+
+
+
+class SessionFactory extends Nette\Object
+{
+
+	/**
+	 * @var Nette\DI\Container
+	 */
+	private $original;
+
+
+
+	public function __construct(Nette\Http\Session $original)
+	{
+		$this->original = $original;
+	}
+
+
+
+	public function create($enabled)
+	{
+		if (!$enabled) {
+			return $this->original;
+		}
+
+		return new Session();
+	}
+
+}


### PR DESCRIPTION
Current implementation generates container only once so it uses session by parameter `enabled` in the first request (http or cli).

This pull request adds factory which evaluates the condition dynamicly in runtime so it uses session implementation as expected.